### PR TITLE
Add dependency in README.md for coreutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Bugcrowd:<br />
 ```
 brew install jq
 brew install gnu-sed
+brew install coreutils
 
 ln -fs "$(pwd)/bountyplz" /usr/local/bin/bountyplz
 ```


### PR DESCRIPTION
Hi

I had a little issue using bountyplz at first as it seems `coreutils` is necessary on macOS to use realpath. 

```
$ bountyplz bc awsog acuity.md
/usr/local/bin/bountyplz: line 3: realpath: command not found
usage: dirname path
/usr/local/bin/bountyplz: line 5: /.env: No such file or directory
```

It might be helpful to others to just mention this in the installation guide.

Thanks!